### PR TITLE
Update broken link for graduation policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This repository contains a [proposal template](proposal), a [literature review t
 
 ## Master Thesis Process
 
-- **Very important: read the [manual](https://www.tudelft.nl/en/student/faculties/eemcs-student-portal/education/graduation-policy-msc/summary-of-procedure/)**. Your advisor will never have to remind you of any of the things mentioned in there. It's your own responsibility to remind your advisor of each step, with an email (e.g., to create a committee for the thesis, to schedule a thesis defense, etc.). 
+- **Very important: read the [manual](https://www.tudelft.nl/en/student/faculties/eemcs-student-portal/education/graduation-policy-msc/)**. Your advisor will never have to remind you of any of the things mentioned in there. It's your own responsibility to remind your advisor of each step, with an email (e.g., to create a committee for the thesis, to schedule a thesis defense, etc.). 
 - Write a research proposal. Read the guide on how to write a research proposal, along with the template. 
 - Send an email to Geert-Jan Houben and setup a meeting with him.
 - After Geert-Jan Houben approves the thesis plan, he will have to sign a couple of forms you are officially a MSc thesis candidate with a clear subject and plan.


### PR DESCRIPTION
This PR updates the broken link to the graduation policy manual from TU Delft website.